### PR TITLE
In memory

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,25 @@
+name: Code quality
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  code-quality:
+    name: Code quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Unit tests
+        run: go test ./... -v -short

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ env-up:
 test:
 	docker exec research-online-redis-go-app go test ./... -v -count=1
 
+bench-go-sequence:
+	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-go-10x-10000x-sequence.txt
+	benchstat ./output/bench-go-10x-10000x-sequence.txt
+
 bench-redis-sequence:
 	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-redis-10x-10000x-sequence.txt
 
@@ -12,6 +16,10 @@ bench-keydb-sequence:
 
 bench-dragonflydb-sequence:
 	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Dragonflydb(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-dragonflydb-10x-10000x-sequence.txt
+
+bench-go-parallel:
+	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-go-10x-10000x-parallel.txt
+	benchstat ./output/bench-go-10x-10000x-parallel.txt
 
 bench-redis-parallel:
 	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-redis-10x-10000x-parallel.txt

--- a/Makefile
+++ b/Makefile
@@ -5,38 +5,42 @@ test:
 	docker exec research-online-redis-go-app go test ./... -v -count=1
 
 bench-go-sequence:
-	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-go-10x-10000x-sequence.txt
-	benchstat ./output/bench-go-10x-10000x-sequence.txt
+	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-go-10x-1000000x-sequence.txt
 
 bench-redis-sequence:
-	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-redis-10x-10000x-sequence.txt
+	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-redis-10x-1000000x-sequence.txt
 
 bench-keydb-sequence:
-	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Keydb(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-keydb-10x-10000x-sequence.txt
+	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Keydb(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-keydb-10x-1000000x-sequence.txt
 
 bench-dragonflydb-sequence:
-	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Dragonflydb(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-dragonflydb-10x-10000x-sequence.txt
+	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Dragonflydb(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-dragonflydb-10x-1000000x-sequence.txt
 
 bench-go-parallel:
-	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-go-10x-10000x-parallel.txt
-	benchstat ./output/bench-go-10x-10000x-parallel.txt
+	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-go-10x-1000000x-parallel.txt
 
 bench-redis-parallel:
-	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-redis-10x-10000x-parallel.txt
+	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Redis(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-redis-10x-1000000x-parallel.txt
 
 bench-keydb-parallel:
-	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Keydb(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-keydb-10x-10000x-parallel.txt
+	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Keydb(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-keydb-10x-1000000x-parallel.txt
 
 bench-dragonflydb-parallel:
-	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Dragonflydb(Hash|SortedSet|Set)' -benchmem -benchtime=10000x -count=10 | tee ./output/bench-dragonflydb-10x-10000x-parallel.txt
+	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Dragonflydb(Hash|SortedSet|Set)' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-dragonflydb-10x-1000000x-parallel.txt
 
-bench: bench-redis-sequence bench-keydb-sequence bench-dragonflydb-sequence bench-redis-parallel bench-keydb-parallel bench-dragonflydb-parallel
-	benchstat ./output/bench-redis-10x-10000x-sequence.txt
-	benchstat ./output/bench-keydb-10x-10000x-sequence.txt
-	benchstat ./output/bench-dragonflydb-10x-10000x-sequence.txt
-	benchstat ./output/bench-redis-10x-10000x-parallel.txt
-	benchstat ./output/bench-keydb-10x-10000x-parallel.txt
-	benchstat ./output/bench-dragonflydb-10x-10000x-parallel.txt
+bench:
+	make bench-go-sequence bench-redis-sequence bench-keydb-sequence bench-dragonflydb-sequence
+	make bench-go-parallel bench-redis-parallel bench-keydb-parallel bench-dragonflydb-parallel
+
+	benchstat ./output/bench-go-10x-1000000x-sequence.txt
+	benchstat ./output/bench-redis-10x-1000000x-sequence.txt
+	benchstat ./output/bench-keydb-10x-1000000x-sequence.txt
+	benchstat ./output/bench-dragonflydb-10x-1000000x-sequence.txt
+
+	benchstat ./output/bench-go-10x-1000000x-parallel.txt
+	benchstat ./output/bench-redis-10x-1000000x-parallel.txt
+	benchstat ./output/bench-keydb-10x-1000000x-parallel.txt
+	benchstat ./output/bench-dragonflydb-10x-1000000x-parallel.txt
 
 bench-redis-memory-25m:
 	docker exec research-online-redis-1 redis-cli flushall

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ https://dou.ua/forums/topic/35260/
 # Databases
 | Name                                                    | Stars  | Language                               |
 |---------------------------------------------------------|--------|----------------------------------------|
-| [Redis](https://github.com/redis/redis)                 | 59100+ | [C](https://dou.ua/forums/tags/C/)     |
-| [KeyDB](https://github.com/Snapchat/KeyDB)              | 7100+  | [C++](https://dou.ua/forums/tags/C++/) |
-| [DragonflyDB](https://github.com/dragonflydb/dragonfly) | 18300+ | [C++](https://dou.ua/forums/tags/C++/) |
+| [Redis](https://github.com/redis/redis)                 | 60900+ | [C](https://dou.ua/forums/tags/C/)     |
+| [KeyDB](https://github.com/Snapchat/KeyDB)              | 7800+  | [C++](https://dou.ua/forums/tags/C++/) |
+| [DragonflyDB](https://github.com/dragonflydb/dragonfly) | 20700+ | [C++](https://dou.ua/forums/tags/C++/) |
 
 # Data structure usage examples
 ### Hash
@@ -230,3 +230,20 @@ make bench-dragonflydb-memory-10k-batch-10k
 
 # Star history of Redis vs KeyDB vs DragonflyDB
 [![Star History Chart](https://api.star-history.com/svg?repos=redis/redis,Snapchat/KeyDB,dragonflydb/dragonfly&type=Date)](https://star-history.com/#redis/redis&Snapchat/KeyDB&dragonflydb/dragonfly&Date)
+
+# Versions
+```bash
+docker pull redis:latest
+docker pull eqalpha/keydb:latest
+docker pull docker.dragonflydb.io/dragonflydb/dragonfly
+```
+```bash
+docker image inspect redis:latest --format '{{.RepoDigests}} {{.Size}}'
+docker image inspect eqalpha/keydb:latest --format '{{.RepoDigests}} {{.Size}}'
+docker image inspect docker.dragonflydb.io/dragonflydb/dragonfly --format '{{.RepoDigests}} {{.Size}}'
+```
+| Database name | Docker image                                                            | Docker image size |
+|---------------|-------------------------------------------------------------------------|-------------------|
+| Redis         | sha256:b0bdc1a83caf43f9eb74afca0fcfd6f09bea38bb87f6add4a858f06ef4617538 | 129.93 MB         |
+| KeyDB         | sha256:c6c09ea6f80b073e224817e9b4a554db7f33362e8321c4084701884be72eed67 | 129.09 MB         |
+| DragonflyDB   | sha256:73b995caf8fa8e3a00928ac5843864ba7f6a8b80ba959eff53386dd9cbb8b589 | 188.90 MB         |

--- a/go_online_storage.go
+++ b/go_online_storage.go
@@ -1,0 +1,61 @@
+package research_online_redis_go
+
+import (
+	"context"
+	"sync"
+)
+
+type GoOnlineStorage struct {
+	mu   sync.Mutex
+	data map[int64]int64
+}
+
+func NewGoOnlineStorage() *GoOnlineStorage {
+	return &GoOnlineStorage{
+		data: map[int64]int64{},
+	}
+}
+
+func (s *GoOnlineStorage) Store(ctx context.Context, pair UserOnlinePair) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.data[pair.UserID] = pair.Timestamp
+
+	return nil
+}
+
+func (s *GoOnlineStorage) BatchStore(ctx context.Context, pairs []UserOnlinePair) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, pair := range pairs {
+		s.data[pair.UserID] = pair.Timestamp
+	}
+
+	return nil
+}
+
+func (s *GoOnlineStorage) Count(ctx context.Context) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return int64(len(s.data)), nil
+}
+
+func (s *GoOnlineStorage) GetAndClear(ctx context.Context) ([]UserOnlinePair, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]UserOnlinePair, 0, len(s.data))
+	for userID, timestamp := range s.data {
+		result = append(result, UserOnlinePair{
+			UserID:    userID,
+			Timestamp: timestamp,
+		})
+	}
+
+	s.data = map[int64]int64{}
+
+	return result, nil
+}

--- a/go_online_storage_test.go
+++ b/go_online_storage_test.go
@@ -1,0 +1,19 @@
+package research_online_redis_go
+
+import (
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var goStorageConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
+	return NewGoOnlineStorage()
+}
+
+func TestGoOnlineStorage(t *testing.T) {
+	testOnlineStorage(t, "redis1:6379", goStorageConstructor)
+}
+
+func BenchmarkGoOnlineStorage(b *testing.B) {
+	benchmarkOnlineStorage(b, "redis1:6379", goStorageConstructor)
+}

--- a/go_online_storage_test.go
+++ b/go_online_storage_test.go
@@ -1,19 +1,105 @@
 package research_online_redis_go
 
 import (
+	"context"
+	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
 )
 
-var goStorageConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
-	return NewGoOnlineStorage()
-}
-
 func TestGoOnlineStorage(t *testing.T) {
-	testOnlineStorage(t, "redis1:6379", goStorageConstructor)
+	testMapOnlineStorage(t, NewGoOnlineStorage())
 }
 
 func BenchmarkGoOnlineStorage(b *testing.B) {
-	benchmarkOnlineStorage(b, "redis1:6379", goStorageConstructor)
+	benchmarkMapOnlineStorage(b, NewGoOnlineStorage())
+}
+
+func testMapOnlineStorage(
+	t *testing.T,
+	storage OnlineStorage,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	expected := []UserOnlinePair{
+		{
+			UserID:    10000001,
+			Timestamp: 1679800725,
+		},
+		{
+			UserID:    10000002,
+			Timestamp: 1679800730,
+		},
+		{
+			UserID:    10000003,
+			Timestamp: 1679800735,
+		},
+	}
+
+	for _, pair := range expected {
+		err := storage.Store(ctx, pair)
+
+		require.NoError(t, err)
+	}
+
+	actualCount, err := storage.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(expected)), int64(actualCount))
+
+	actual, err := storage.GetAndClear(ctx)
+	require.NoError(t, err)
+
+	requireUserOnlinePairsEqual(t, expected, actual)
+}
+
+func benchmarkMapOnlineStorage(
+	b *testing.B,
+	storage OnlineStorage,
+) {
+	b.Helper()
+
+	ctx := context.Background()
+
+	var (
+		startTimestamp = time.Now().Unix()
+		startUserID    = int64(1e7)
+	)
+
+	b.ResetTimer()
+	if os.Getenv("MODE") == "parallel" {
+		var (
+			counter = int64(0)
+		)
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				index := atomic.AddInt64(&counter, 1)
+
+				err := storage.Store(ctx, UserOnlinePair{
+					UserID:    startUserID + index,
+					Timestamp: startTimestamp + index,
+				})
+
+				require.NoError(b, err)
+			}
+		})
+	} else {
+		for index := int64(0); index < int64(b.N); index++ {
+			err := storage.Store(ctx, UserOnlinePair{
+				UserID:    startUserID + index,
+				Timestamp: startTimestamp + index,
+			})
+
+			require.NoError(b, err)
+		}
+	}
+
+	actualCount, err := storage.Count(ctx)
+	require.NoError(b, err)
+	require.Equal(b, int64(b.N), actualCount)
 }

--- a/hash_online_storage_test.go
+++ b/hash_online_storage_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var hashOnlineStorageConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
+var hashOnlineStorageConstructor = func(client *redis.Client) OnlineStorage {
 	return NewHashOnlineStorage(client)
 }
 

--- a/redis_client_test.go
+++ b/redis_client_test.go
@@ -9,28 +9,25 @@ import (
 )
 
 func TestRedisPing(t *testing.T) {
-	client := redis.NewClient(&redis.Options{
-		Addr: "redis1:6379",
-	})
-
-	result, err := client.Ping(context.Background()).Result()
-	require.NoError(t, err)
-	require.Equal(t, "PONG", result)
+	testPing(t, "redis1:6379")
 }
 
 func TestKeydbPing(t *testing.T) {
-	client := redis.NewClient(&redis.Options{
-		Addr: "keydb1:6379",
-	})
-
-	result, err := client.Ping(context.Background()).Result()
-	require.NoError(t, err)
-	require.Equal(t, "PONG", result)
+	testPing(t, "keydb1:6379")
 }
 
 func TestDragonflydbPing(t *testing.T) {
+	testPing(t, "dragonflydb1:6379")
+}
+
+func testPing(t *testing.T, addr string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip()
+	}
+
 	client := redis.NewClient(&redis.Options{
-		Addr: "dragonflydb1:6379",
+		Addr: addr,
 	})
 
 	result, err := client.Ping(context.Background()).Result()

--- a/set_online_storage_test.go
+++ b/set_online_storage_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	setOnlineStorageTestConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
+	setOnlineStorageTestConstructor = func(client *redis.Client) OnlineStorage {
 		return NewSetOnlineStorage(client, 1)
 	}
-	setOnlineStorageBenchmarkConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
+	setOnlineStorageBenchmarkConstructor = func(client *redis.Client) OnlineStorage {
 		return NewSetOnlineStorage(client, 1800)
 	}
 )

--- a/sorted_set_online_storage_test.go
+++ b/sorted_set_online_storage_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var sortedSetOnlineStorageConstructor onlineStorageConstructor = func(client *redis.Client) OnlineStorage {
+var sortedSetOnlineStorageConstructor = func(client *redis.Client) OnlineStorage {
 	return NewSortedSetOnlineStorage(client)
 }
 


### PR DESCRIPTION
```makefile
bench-go-sequence:
	docker exec -e MODE=sequence research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-go-10x-1000000x-sequence.txt
	benchstat ./output/bench-go-10x-1000000x-sequence.txt
```
```text
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkGoOnlineStorage
BenchmarkGoOnlineStorage-12    	 1000000	       511.6 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       497.7 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       495.0 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       512.1 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       501.4 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       535.0 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       495.9 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       495.6 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       497.4 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       541.0 ns/op	      87 B/op	       0 allocs/op
PASS
ok  	github.com/doutivity/research-online-redis-go	5.118s
```
```text
name                time/op
GoOnlineStorage-12  508ns ± 6%

name                alloc/op
GoOnlineStorage-12  87.0B ± 0%

name                allocs/op
GoOnlineStorage-12   0.00     
```

```makefile
bench-go-parallel:
	docker exec -e MODE=parallel research-online-redis-go-app go test ./... -v -run=$$^ -bench='Go' -benchmem -benchtime=1000000x -count=10 | tee ./output/bench-go-10x-1000000x-parallel.txt
	benchstat ./output/bench-go-10x-1000000x-parallel.txt
```
```text
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkGoOnlineStorage
BenchmarkGoOnlineStorage-12    	 1000000	       913.3 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       828.1 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       877.1 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       948.2 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       932.0 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       781.2 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       875.9 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	      1067 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       765.8 ns/op	      87 B/op	       0 allocs/op
BenchmarkGoOnlineStorage-12    	 1000000	       752.3 ns/op	      87 B/op	       0 allocs/op
PASS
ok  	github.com/doutivity/research-online-redis-go	8.777s
```
```text
name                time/op
GoOnlineStorage-12  874ns ±22%

name                alloc/op
GoOnlineStorage-12  87.0B ± 0%

name                allocs/op
GoOnlineStorage-12   0.00   
```